### PR TITLE
asan: Really don't intercept memset in arch/x86/boot

### DIFF
--- a/arch/x86/boot/compressed/eboot.c
+++ b/arch/x86/boot/compressed/eboot.c
@@ -7,6 +7,12 @@
  *
  * ----------------------------------------------------------------------- */
 
+/*
+ * Since the binaries in arch/x86/boot are not linked with ASAN runtime library,
+ * we must not replace memset with asan_memset, etc.
+ */
+#define ASAN_NO_INTERCEPTORS
+
 #include <linux/efi.h>
 #include <linux/pci.h>
 #include <asm/efi.h>

--- a/arch/x86/boot/compressed/eboot.h
+++ b/arch/x86/boot/compressed/eboot.h
@@ -1,12 +1,6 @@
 #ifndef BOOT_COMPRESSED_EBOOT_H
 #define BOOT_COMPRESSED_EBOOT_H
 
-/*
- * Since the binaries in arch/x86/boot are not linked with ASAN runtime library,
- * we must not replace memset with asan_memset, etc.
- */
-#define ASAN_NO_INTERCEPTORS
-
 #define SEG_TYPE_DATA		(0 << 3)
 #define SEG_TYPE_READ_WRITE	(1 << 1)
 #define SEG_TYPE_CODE		(1 << 3)


### PR DESCRIPTION
This PR fixes the following link errors with make oldconfig based on Debian's 3.15 kernel:
...
arch/x86/boot/compressed/eboot.o: In function `setup_graphics':
eboot.c:(.text+0x136c): undefined reference to`asan_memset'
arch/x86/boot/compressed/eboot.o: In function `make_boot_params':
eboot.c:(.text+0x2149): undefined reference to`asan_memset'
...

It would be really nice to upstream kasan to GCC and to Linux even if it is not perfect yet.
