### PR TITLE
mm: kasan: fix redzone shadow poisoning in Slub

### DIFF
--- a/include/linux/kasan.h
+++ b/include/linux/kasan.h
@@ -32,8 +32,10 @@ void kasan_unpoison_shadow(const void *address, size_t size);
 
 void kasan_alloc_pages(struct page *page, unsigned int order);
 void kasan_free_pages(struct page *page, unsigned int order);
-void kasan_mark_slab_padding(struct kmem_cache *s, void *object,
-			struct page *page);
+
+void kasan_poison_slab(struct page *page);
+void kasan_pre_ctor(struct kmem_cache *cache, void *object);
+void kasan_post_ctor(struct kmem_cache *cache, void *object);
 
 void kasan_kmalloc_large(const void *ptr, size_t size);
 void kasan_kfree_large(const void *ptr);
@@ -52,8 +54,11 @@ static inline void kasan_disable_local(void) {}
 
 static inline void kasan_alloc_pages(struct page *page, unsigned int order) {}
 static inline void kasan_free_pages(struct page *page, unsigned int order) {}
-static inline void kasan_mark_slab_padding(struct kmem_cache *s, void *object,
-					struct page *page) {}
+
+static inline void kasan_poison_slab(struct page *page) {}
+static inline void kasan_pre_ctor(struct kmem_cache *cache, void *object) {}
+static inline void kasan_post_ctor(struct kmem_cache *cache, void *object) {}
+
 
 static inline void kasan_kmalloc_large(void *ptr, size_t size) {}
 static inline void kasan_kfree_large(const void *ptr) {}

--- a/include/linux/slub_def.h
+++ b/include/linux/slub_def.h
@@ -118,8 +118,6 @@ static inline void *virt_to_obj(struct kmem_cache *s, void *slab_page, void *x)
 	return x - ((x - slab_page) % s->size);
 }
 
-__printf(3, 4)
-void slab_err(struct kmem_cache *s, struct page *page, const char *fmt, ...);
 void object_err(struct kmem_cache *s, struct page *page,
 		u8 *object, char *reason);
 

--- a/mm/kasan/kasan.h
+++ b/mm/kasan/kasan.h
@@ -8,7 +8,6 @@
 
 #define KASAN_FREE_PAGE         0xFF  /* page was freed */
 #define KASAN_PAGE_REDZONE      0xFE  /* redzone for kmalloc_large allocations */
-#define KASAN_SLAB_PADDING      0xFD  /* Slab page padding, does not belong to any slub object */
 #define KASAN_KMALLOC_REDZONE   0xFC  /* redzone inside slub object */
 #define KASAN_KMALLOC_FREE      0xFB  /* object was freed (kmem_cache_free/kfree) */
 #define KASAN_SHADOW_GAP        0xF9  /* address belongs to shadow memory */


### PR DESCRIPTION
kasan_slab_alloc() and kasan_slab_free() appeared to be broken:
When slab it set up, kasan_slab_free() is called on each object. It
  poisons the object only, not the redzone/metadata.

Instead, in this change we poison the (shadow of) whole slab on setup,
and unpoison only the objects on allocation

Effectively this fixes most of left out of bounds misses.

kasan_mark_slab_padding and KASAN_SLAB_PADDING aren't used any more

Signed-off-by: Dmitry Chernenkov dmitryc@google.com
